### PR TITLE
Max GitHub versions

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -10,22 +10,23 @@ import (
 	"github.com/jessevdk/go-flags"
 )
 
-// CLI Options
+// Options describes all the cli flags that can be passed
 type Options struct {
-	Port         int           `short:"p" long:"port" description:"Port to listen on" default:"443" env:"BARYON_PORT"`
-	Bind         string        `short:"b" long:"bind" description:"Ip address to bind to" default:"0.0.0.0" env:"BARYON_BIND"`
-	Secret       string        `short:"s" long:"secret" description:"The web-hook secret" env:"BARYON_HOOK_SECRET"`
-	Key          string        `short:"k" long:"key" description:"Specify a Key file to enable server to start TLS" env:"BARYON_KEY"`
-	Cert         string        `short:"c" long:"cert" description:"Cert file for TLS" env:"BARYON_CERT"`
-	Org          string        `short:"o" long:"org" description:"Github Org to find cookbooks" env:"BARYON_GITHUB_ORG"`
-	Token        string        `short:"t" long:"token" description:"Github API token to use when connecting" env:"BARYON_GITHUB_TOKEN"`
-	SyncInterval time.Duration `short:"i" long:"interval" description:"Interval to perform full sync against github repos. Supports Golang duration formatting '1h2m'... etc." default:"12h" env:"BARYON_INTERVAL"`
-	NoSync       bool          `long:"no-sync" description:"Do NOT perform a github scan/sync when starting. Periodic sync will still fire" env:"BARYON_NOSYNC"`
-	BerksOnly    bool          `long:"berks-only" description:"Only use berks compatable version tags in the universe" env:"BARYON_BERKSONLY"`
-	TLS          bool
+	Port              int           `short:"p" long:"port" description:"Port to listen on" default:"443" env:"BARYON_PORT"`
+	Bind              string        `short:"b" long:"bind" description:"Ip address to bind to" default:"0.0.0.0" env:"BARYON_BIND"`
+	Secret            string        `short:"s" long:"secret" description:"The web-hook secret" env:"BARYON_HOOK_SECRET"`
+	Key               string        `short:"k" long:"key" description:"Specify a Key file to enable server to start TLS" env:"BARYON_KEY"`
+	Cert              string        `short:"c" long:"cert" description:"Cert file for TLS" env:"BARYON_CERT"`
+	Org               string        `short:"o" long:"org" description:"Github Org to find cookbooks" env:"BARYON_GITHUB_ORG"`
+	Token             string        `short:"t" long:"token" description:"Github API token to use when connecting" env:"BARYON_GITHUB_TOKEN"`
+	SyncInterval      time.Duration `short:"i" long:"interval" description:"Interval to perform full sync against github repos. Supports Golang duration formatting '1h2m'... etc." default:"12h" env:"BARYON_INTERVAL"`
+	NoSync            bool          `long:"no-sync" description:"Do NOT perform a github scan/sync when starting. Periodic sync will still fire" env:"BARYON_NOSYNC"`
+	BerksOnly         bool          `long:"berks-only" description:"Only use berks compatable version tags in the universe" env:"BARYON_BERKSONLY"`
+	MaxGithubVersions int           `logn:"max-github-versions" description:"Max number of versions to scan when  looking at github repos" default:"20" env:"BARYON_MAX_VERSIONS"`
+	TLS               bool
 }
 
-// Opts is the application config struct
+// Opts is the application config struct that we allow external access too
 var Opts Options
 
 func init() {

--- a/main.go
+++ b/main.go
@@ -34,7 +34,7 @@ func main() {
 		Token:        config.Opts.Token,
 		Org:          config.Opts.Org,
 		SyncInterval: config.Opts.SyncInterval,
-		MaxVersions:  5,
+		MaxVersions:  config.Opts.MaxGithubVersions,
 	}
 	ghs := gh.New(ghsConfig, u)
 	var wg sync.WaitGroup


### PR DESCRIPTION
Allows you to configure the github sources max versions per repo. 

Also bumps default from 5 to 20. This was originally an optimization for lowering the amount of requests to the API. Now that we know where we stand on tokens/usage bumping it and allowing it to be configurable makes sense.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pantheon-systems/baryon/10)

<!-- Reviewable:end -->
